### PR TITLE
Feat/chatlog cmd

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/game/commands/CommandManager.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/commands/CommandManager.java
@@ -59,6 +59,7 @@ public class CommandManager {
         tempCommands.put(new String[] { "rgb", "rainbow" }, new RainbowDimmerCommand());
         tempCommands.put(new String[] { "afk", "idle" }, new AfkCommand());
         tempCommands.put(new String[] { "guidestatus" }, new GuideStatusCommand());
+        tempCommands.put(new String[] {"cl", "chatlog", "wys"}, new ChatlogCommand());
 
         // Staff commands
         tempCommands.put(new String[] { "copyroom" }, new CopyRoomCommand());

--- a/Havana-Server/src/main/java/org/alexdev/havana/game/commands/registered/ChatlogCommand.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/commands/registered/ChatlogCommand.java
@@ -1,0 +1,56 @@
+package org.alexdev.havana.game.commands.registered;
+
+import org.alexdev.havana.dao.mysql.RoomDao;
+import org.alexdev.havana.game.commands.Command;
+import org.alexdev.havana.game.entity.Entity;
+import org.alexdev.havana.game.entity.EntityType;
+import org.alexdev.havana.game.moderation.ChatMessage;
+import org.alexdev.havana.game.player.Player;
+import org.alexdev.havana.game.player.PlayerRank;
+import org.alexdev.havana.messages.outgoing.alerts.ALERT;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+
+public class ChatlogCommand extends Command {
+    @Override
+    public void setPlayerRank() {
+        super.setPlayerRank(PlayerRank.NORMAL);
+    }
+
+    @Override
+    public void handleCommand(Entity entity, String message, String[] args) {
+        var roomChatLogs = RoomDao.getModChatlog(entity.getRoomUser().getRoom().getId());
+
+        StringBuilder viewableLogs = new StringBuilder();
+
+        var sortedChatLogs = roomChatLogs.stream()
+                .filter(msg -> msg.getSentTime() > entity.getRoomUser().getEnteredRoomAt())
+                .sorted(Comparator.comparing(ChatMessage::getSentTime))
+                .toList();
+
+        for (var commandSet : sortedChatLogs) {
+            LocalDateTime dateTime = LocalDateTime.ofEpochSecond(commandSet.getSentTime(), 0, java.time.ZoneOffset.UTC);
+            String formattedTime = dateTime.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+
+            viewableLogs.append("[").append(formattedTime).append("] ");
+            viewableLogs.append(commandSet.getPlayerName());
+            viewableLogs.append(": ");
+            viewableLogs.append(commandSet.getMessage());
+            viewableLogs.append("<br>");
+        }
+
+        if (entity.getType() == EntityType.PLAYER) {
+            Player player = (Player) entity;
+            player.send(new ALERT(viewableLogs.toString()));
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "Display chat log for current room.";
+    }
+}
+
+

--- a/Havana-Server/src/main/java/org/alexdev/havana/game/room/entities/RoomEntity.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/room/entities/RoomEntity.java
@@ -26,12 +26,10 @@ import org.alexdev.havana.game.wordfilter.WordfilterManager;
 import org.alexdev.havana.messages.outgoing.effects.USER_AVATAR_EFFECT;
 import org.alexdev.havana.messages.outgoing.rooms.user.*;
 import org.alexdev.havana.messages.types.MessageComposer;
+import org.alexdev.havana.util.DateUtil;
 import org.alexdev.havana.util.config.GameConfiguration;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -75,12 +73,15 @@ public abstract class RoomEntity {
     private int carryId;
     private String carryValue;
 
+    private long enteredRoomAt;
+
     public RoomEntity(Entity entity) {
         this.entity = entity;
         this.statuses = new ConcurrentHashMap<>();
         this.path = new LinkedList<>();
         this.packetQueueAfterRoomLeave = new LinkedBlockingQueue<MessageComposer>();
         this.timerManager = new RoomTimerManager(this);
+        this.enteredRoomAt = DateUtil.getCurrentTimeSeconds();
     }
 
     public void reset() {
@@ -103,6 +104,7 @@ public abstract class RoomEntity {
         this.pixelAvailableTick = new AtomicInteger(GameConfiguration.getInstance().getInteger("pixels.max.tries.single.room.instance"));
         this.chatMessages = new CopyOnWriteArrayList<>();
         this.timerManager.resetTimers();
+        this.enteredRoomAt = 0;
     }
 
     /**
@@ -1078,4 +1080,11 @@ public abstract class RoomEntity {
         return pixelAvailableTick;
     }
 
+    public long getEnteredRoomAt() {
+        return enteredRoomAt;
+    }
+
+    public void setEnteredRoomAt() {
+        this.enteredRoomAt = DateUtil.getCurrentTimeSeconds();
+    }
 }

--- a/Havana-Server/src/main/java/org/alexdev/havana/game/room/managers/RoomEntityManager.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/game/room/managers/RoomEntityManager.java
@@ -183,6 +183,7 @@ public class RoomEntityManager {
         entity.getRoomUser().reset();
         entity.getRoomUser().setRoom(this.room);
         entity.getRoomUser().setInstanceId(this.generateUniqueId());
+        entity.getRoomUser().setEnteredRoomAt();
 
         Position entryPosition = this.room.getModel().getDoorLocation();
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Originally started as a fork from [Quackster/Kepler](https://github.com/Quackster/Kepler), this is a server created in Java designed to revive Habbo Hotel v31 from the 2009 era and its inception was in early 2018 as a side project. Havana is the most complete v31+ server to date, this was undertaken by various reverse engineering efforts of the Shockwave client throughout the years to achieve this.
 
-Havana has been an independent project, almost entirely developed by [myself](https://github.com/Quackster) for 4 years straight. This project means a lot to me, and was always going to be released as open-source work. I am a firm believer in open-source and free software for everybody.
+**Join the Classic Habbo discord!** https://discord.gg/GEYbVpW
 
-*Want to see this project live?* Visit [ClassicHabbo.com](https://classicHabbo.com/) where we have been running the hotel for 4+ years straight, reviving old memories and creating new ones.
+Havana has been an independent project, almost entirely developed by [myself](https://github.com/Quackster) for 4 years straight. This project means a lot to me, and was always going to be released as open-source work. I am a firm believer in open-source and free software for everybody.
 
 Sulake used the Adobe/Macromedia Shockwave as its multimedia platform for their game (Habbo Hotel) from 2001-2009. In the last year, Habbo made the move to the Adobe Flash client, and then in 2020 made the switch to the Unity engine, while still maintaining their flash client.
 
@@ -178,11 +178,11 @@ Download the latest development build from the [releases page](https://github.co
 
 To be honest, this server doesn't require much. I'd argue that the MariaDB server is more resource demanding than the emulator itself. 
 
-- JDK >= 11
+- JDK >= 17
 - MariaDB server
-- libsodium support (this project uses [this library](https://github.com/terl/lazysodium-java))
+- At minimum 4 GB of RAM (to be safe)
 
-If you aim to use this for yourself, I recommend setting up your own 2009 figure image renderer with the project I've created [here](https://github.com/Quackster/Avatara) to render Habbo looks on the website.
+If you aim to use this for yourself, I recommend setting up your own 2009 figure image renderer with the project I've created [here](https://github.com/Quackster/Minerva) to render Habbo looks on the website.
 
 # Installation
 
@@ -190,7 +190,7 @@ Install MariaDB server, connect to the database server and import havana.sql (lo
 
 Download the latest development build from the [releases page](https://github.com/Quackster/Havana/releases) and rename the files to remove the short build hash version, for convenience. 
 
-Install any JDK version that is equal or above >= 11 to run the jar files.
+Install any JDK version that is equal or above >= 17 to run the jar files.
 
 Run both Havana-Server.jar and Havana-Web.jar at least once to generate the necessary configuration files, configure the MySQL attributes to connect to the MariaDB server.
 
@@ -208,7 +208,7 @@ I highly recommend [this browser](https://forum.ragezone.com/f353/portable-brows
 
 ❗ Once registered as an admin, I high recommend running [groups.sql](https://github.com/Quackster/Havana/blob/master/tools/groups.sql) against your database, it will create the Habbo Guides, SnowStorm, BattleBall, Wobble Squabble and Lido Diving gaming groups for the website.
 
-And then make yourself admin by setting your ``rank`` to 7 in the ``users`` table.
+And then make yourself admin by setting your ``rank`` to 8 in the ``users`` table.
 
 ### Important for Linux users
 


### PR DESCRIPTION
Use `:wys, :cl, or :chatlog` to view the chat log in the current room since the time the user entered the room. This means users will not see chat msgs from before they entered the room.

Right now this is missing pagination and is printing to a client UI element that does not support scrolling. Which means this probably breaks after the room chat log gets too large.

Either add pagination or figure out a way to get scrolling working.