### PR TITLE
fix bug when purchasing rares + add ecotron random chance event

### DIFF
--- a/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/ecotron/RECYCLE_ITEMS.java
+++ b/Havana-Server/src/main/java/org/alexdev/havana/messages/incoming/ecotron/RECYCLE_ITEMS.java
@@ -1,15 +1,16 @@
 package org.alexdev.havana.messages.incoming.ecotron;
 
+import org.alexdev.havana.dao.mysql.CurrencyDao;
 import org.alexdev.havana.dao.mysql.ItemDao;
-import org.alexdev.havana.game.catalogue.CatalogueManager;
 import org.alexdev.havana.game.item.Item;
 import org.alexdev.havana.game.item.ItemManager;
 import org.alexdev.havana.game.player.Player;
+import org.alexdev.havana.game.player.PlayerManager;
 import org.alexdev.havana.messages.outgoing.ecotron.RECYCLER_STATUS;
 import org.alexdev.havana.messages.outgoing.rooms.items.ITEM_DELIVERED;
+import org.alexdev.havana.messages.outgoing.user.currencies.CREDIT_BALANCE;
 import org.alexdev.havana.messages.types.MessageEvent;
 import org.alexdev.havana.server.netty.streams.NettyRequest;
-import org.alexdev.havana.util.config.GameConfiguration;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +80,42 @@ public class RECYCLE_ITEMS implements MessageEvent {
             return;
         }*/
 
+        double clubCreditChance = 0.2;
+        double normalCreditChance = 0.1;
+
+        boolean rewardCredits = false;
+
+        if (player.getDetails().hasClubSubscription()) {
+            // if player is habbo club 20% chance they will earn credits.
+            if (Math.random() <= clubCreditChance) {
+                rewardCredits = true;
+            }
+        } else {
+            // if normal player then 10% chance they will earn credits.
+            if (Math.random() <= normalCreditChance) {
+                rewardCredits = true;
+            }
+        }
+
+        if (rewardCredits) {
+            // pay the user 50 credits instead of a gift
+            for (Item item : itemsToDelete) {
+                player.getInventory().getItems().remove(item);
+                item.delete();
+            }
+
+            CurrencyDao.increaseCredits(player.getDetails(), 50);
+
+            var user = PlayerManager.getInstance().getPlayerById(player.getDetails().getId());
+
+            if (user != null) {
+                user.send(new CREDIT_BALANCE(user.getDetails().getCredits()));
+            }
+
+            player.send(new ITEM_DELIVERED());
+            player.send(new RECYCLER_STATUS(1));
+            return;
+        }
 
         Item present = new Item();
         present.setDefinitionId(ItemManager.getInstance().getDefinitionBySprite("ecotron_box").getId());


### PR DESCRIPTION
This PR fixes a bug in the packet handler for purchasing items from the catalogue. Previously users were unable to buy the daily rare because of an incorrect check in GRPC.

This also adds a random chance event to the recycler. Normal users have a 10% chance of earning credits instead of getting the recycler rare. Habbo Club users have a 20% chance of earning credits instead of getting the recycler rare. This is the beginning of a random chance system that adds more utility to the recycler as well as providing value to normal furniture items.