### PR TITLE
feat: enable the shockwave help sections on site

### DIFF
--- a/Havana-Web/src/main/java/org/alexdev/http/Routes.java
+++ b/Havana-Web/src/main/java/org/alexdev/http/Routes.java
@@ -61,9 +61,9 @@ public class Routes {
         RouteManager.addRoute("/credits/club/tryout", ClubController::clubTryout);
         RouteManager.addRoute("/tag", TagController::tag);
         RouteManager.addRoute("/tag/*", TagController::search);
-        //RouteManager.addRoute("/help/install_shockwave", SiteController::install_shockwave);
-        //RouteManager.addRoute("/help/shockwave_app", SiteController::shockwave_app);
-        RouteManager.addRoute("/help/*", FaqController::faq);
+        RouteManager.addRoute("/help/install_shockwave", SiteController::install_shockwave);
+        RouteManager.addRoute("/help/shockwave_app", SiteController::shockwave_app);
+        //RouteManager.addRoute("/help/*", FaqController::faq);
 
         // Client
         RouteManager.addRoute("/components/updateHabboCount", ClientController::updateHabboCount);

--- a/Havana-Web/src/main/java/org/alexdev/http/controllers/site/SiteController.java
+++ b/Havana-Web/src/main/java/org/alexdev/http/controllers/site/SiteController.java
@@ -16,4 +16,18 @@ public class SiteController {
         template.render();
     }
 
+    public static void install_shockwave(WebConnection webConnection) {
+        XSSUtil.clear(webConnection);
+
+        var template = webConnection.template("install_shockwave");
+        template.render();
+    }
+
+    public static void shockwave_app(WebConnection webConnection) {
+        XSSUtil.clear(webConnection);
+
+        var template = webConnection.template("shockwave_app");
+        template.render();
+    }
 }
+

--- a/tools/www-tpl/default-en/install_shockwave.tpl
+++ b/tools/www-tpl/default-en/install_shockwave.tpl
@@ -117,13 +117,13 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 						<p><b>Shockwave 12</b></p>
 						<p>You must install the Shockwave 12 MSI first and then proceed to install the Visual Studio 2008 C++ x86 redist.</p>
 						<p><i>Download list</i></p>
-						<p>Adobe Shockwave 12.3 MSI: <a href="https://alex-dev.org/shockwave/12.3/sw_lic_full_installer.msi" target="_blank">Download</a></p>
-						<p>Microsoft Visual C++ 2008 Redistributable Package (x86): <a href="https://www.microsoft.com/en-au/download/details.aspx?id=29" target="_blank">Download</a></p>
+						<p>Adobe Shockwave 12.3 MSI: <a href="https://inf-o-matic.com/downloads/Shockwave_Installer_Full_12.3.0.000.msi" target="_blank">Download</a></p>
+						<p>Microsoft Visual C++ 2008 Redistributable Package (x86): <a href="https://www.microsoft.com/en-us/download/details.aspx?id=26368" target="_blank">Download</a></p>
 						<p>Also please make sure you <b>do not have a browser open</b> when installing the Shockwave MSI, as you will need to start a fresh Windows installation, since the current installation breaks with a browser open.</p>
 						<p><b>Shockwave 11</b></p>
 						<p>While Shockwave 11.6 is older than the latest version that is Shockwave 12, the latest version experiences issues with crashing while playing music from the Trax Machine or Jukebox, and also messsages in the instant messenger are always stuck at 12:00.</p>
 						<p>For these reasons, Shockwave 11 is recommended to install instead since these issues are not present in this version.</p>
-						<p>You can download the official Shockwave 11.6 installer MSI <a href="https://alex-dev.org/shockwave/11.6/sw_lic_full_installer.msi">here</a>.</p>
+						<p>You can download the official Shockwave 11.6 installer MSI <a href="https://inf-o-matic.com/downloads/Shockwave_Installer_Full_11.6.0.000.msi">here</a>.</p>
 						
 						<!-- <p><b>Shockwave 12</b></p>
 						<p>If the Shockwave 11 steps do not work, there is another option to install Shockwave 12, but this version brings issues that Shockwave 11 does not have.</p>
@@ -137,17 +137,18 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 			<script type="text/javascript">if (!$(document.body).hasClassName('process-template')) { Rounder.init(); }</script>
 			<div class="habblet-container ">		
 				<div class="cbb clearfix red ">
-					<h2 class="title">Why should I use Shockwave?</h2>
-					<div class="tutorial-text">	
-						<p style="margin-top: 10px">As of right now there are two clients to play the hotel on, the first is the Shockwave hotel and the second is Flash.</p>
-						<p>It is highly recommended to play the Shockwave version because it's filled with far more features that cannot be experienced on the Flash client.</p>
-						<p>The features that Shockwave contains which are not present in the Flash version are listed below.</p>
+					<h2 class="title">What is the best method to play?</h2>
+					<div class="tutorial-text">
+						<p style="margin-top: 10px">It is <b>highly</b> recommended to use the Basilisk portable browser or Pale Moon 32-bit with Shockwave 11.6.</p>
+						<p>The Basilisk browser requires no downloads and comes with Shockwave & Flash already configured which is why it's the preferred method.</p>
+						<p>Read more about the Basilisk portable browser <a href="https://forum.ragezone.com/f353/portable-browser-with-flash-shockwave-1192727/">here</a>.</p>
+						<p>If you prefer to use a desktop client then check out the portable client we have built.</p>
 						<div class="row">
 							<div class="column" style="margin-top:10px; margin-bottom:10px; margin-right:10px">
 								<img src="{{ site.staticContentPath }}/c_images/stickers/sticker_submarine.gif" alt="">
 							</div>
 							<div class="column" style="margin-top:10px; margin-bottom:10px; margin-left:10px; width: 275px;">
-								<p><b>BattleBall, Diving, Wobble Squabble, Trax Machines, Jukeboxes, American Idol, Tic Tac Toe, Chess, Battleships, Poker</b> and some nostalgic Habbo components such as the hand and the Room-o-Matic.</p>
+								<p><b>Both Basilisk and the portable desktop client have been tested on Linux/macOS with Wine, if you're having trouble connecting to the hotel please visit us in Discord.</b></p>
 							</div>
 						</div>
 					</div>
@@ -164,15 +165,17 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 								<img class="credits-image" src="https://i.imgur.com/6zrNiqZ.gif" alt="" width="100" height="100">
 							</div>
 							<div class="column" style="width: 165px;">
-								<p style="margin-top: 10px">The following items are required to use Shockwave are listed below.</p>
-								<p>If you fail to meet these requirements, you will only be able to play the Flash version.</p>
+								<p style="margin-top: 10px">The items listed below are required to use Shockwave.</p>
+								<p>If you fail to meet these requirements you will not be able to play.</p>
 							</div>
 						</div>
 						<p><b>Requirements</b></p> 
-						<p> - Microsoft Windows; or</p>
-						<p> - WINE for Linux and macOS (not supported by Classic staff, as may be unreliable)</p>
+						<p> - Microsoft Windows; or WINE for Linux and macOS</p>
 						<p> - Shockwave (at least 11.6 or higher)</p>
 						<p> - Pale Moon 32-bit</p>
+						<p>   or one of the following</p>
+						<p> - Basilisk Portable Browser. (Download <a href="https://inf-o-matic.com/downloads/Basilisk-Portable.zip">here</a>)</p>
+						<p> - Habbo Desktop Client. (Download <a href="https://inf-o-matic.com/downloads/habbo-client-v0.1.0.zip">here</a>)</p>
 					</div>
 				</div>
 			</div>

--- a/tools/www-tpl/default-en/shockwave_app.tpl
+++ b/tools/www-tpl/default-en/shockwave_app.tpl
@@ -144,11 +144,12 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 							</div>
 						</div>
 						<p><b>How does it work?</b></p>
-						<p>The program is a simple .exe that sends a login request to our server and then loads the client. You'll need to edit the account.ini file with your login details.</p>
-						<p>The app regardless of download will work with WINE, which is a requirement to play on either macOS and Linux.</p>
+						<p>The program is a simple .exe that works as a light wrapper around the Shockwave client files.</p>
+						<p>The app will work natively on Windows but will require Wine or Wineskin Winery to play on Linux/macOS.</p>
+						<p>This method does not require any installs of Shockwave or an additional browser.</p>
 						<p><b>Why should I use Shockwave?</b></p>
-						<p>As of right now there are two clients to play the hotel on, the first is the Shockwave hotel and the second is Flash.</p>
-						<p>It is highly recommended to play the Shockwave version because it's filled with far more features that cannot be experienced on the Flash client.</p>
+						<p>Early versions of Habbo Hotel were built with Macromedia Shockwave and so it is required to load the client.</p>
+						<p>Perhaps one day we will have Ruffle-esque styled emulation for Shockwave but for now this is the best we have.</p>
 						<p><b>Pictures</b></p>
 						<p>Below are pictures of the program working in action.</p>
 						<div class="article-body">
@@ -188,39 +189,12 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 								<img src="https://i.imgur.com/yDbopCD.png" alt="">
 							</div>
 							<div class="text-column" style="width: 365px;">
-								<p>The program has existed since April 2019 and has had a lot of changes over the course. You may view them below.</p>
+								<p>The desktop client was created in early 2023. Changes to the client over time can be found below.</p>
 							</div>
 						</div>
 						<a class="new-button collapsible" id="warn-clear-hand-button" href="#"><b>Reveal Changelog</b><i></i></a>
 						<div class="collapsible-content" style="margin-top: 25px">
-						<p><b>Version 0.8</b></p>
-						<p>- Fixes for Cloudflare changing how requests are sent back.</p>
-						<br>
-						<p><b>Version 0.7</b></p>
-						<p>- Fixes for updating furniture.</p>
-						<br>
-						<p><b>Version 0.6</b></p>
-						<p>- Furniture is now stored and loaded from disk to decrease furniture load times.</p>
-						<p>- New furniture will be automatically downloaded when loaded so subsequent loading will be faster.</p>
-						<br>
-						<p><b>Version 0.5</b></p>
-						<br>
-						<p>- Added hotel view support which is an option that can be changed in your Account Settings.</p>
-						<p>- Added always on top feature.</p>
-						<p>- Added login in the client instead, an opt-in if you don't trust login details being stored on text.</p>
-						<br>
-						<p><b>Version 0.4</b></p>
-						<p>- Added patches for SnowStorm to become playable, without freezing.</p>
-						<br>
-						<p><b>Version 0.3</b></p>
-						<p>- Fix for working hyperlinks</p>
-						<p>- Fix for the reset tutorial button not properly sending request to server.</p>
-						<br>
-						<p><b>Version 0.2</b></p>
-						<p>- Fix for miscellaneous symbols not being allowed in passwords.</p>
-						<p>- Add joystick icon created by Copyright.</p>
-						<br>
-						<p><b>Version 0.1</b></p>
+						<p><b>v0.1.0 - March 2023</b></p>
 						<p>- Initial release.</p>
 						</div>
 						<!-- <p>The features that Shockwave contains which are not present in the Flash version are listed below.</p>
@@ -241,13 +215,13 @@ body { behavior: url({{ site.staticContentPath }}/web-gallery/js/csshover.htc); 
 				<div class="cbb clearfix">
 					<h2 class="title" style="background-color: gray">Downloads</h2>
 					<div class="tutorial-text">							</h2>
-						<p style="margin-top:10px; margin-right:10px">There are two versions to download. The standard download and the lite download.</p>
-						<p><b>Standard version:</b></p>
-						<p>The standard version contains all the furniture for instant loading. New furniture will be downloaded if the file doesn't exist.</p>
-						<p> - <a href="https://classichabbo.com/classichabbo_exe.zip">Click here</a> to download (82 MB)</p>
-						<p><b>Lite version:</b></p>
-						<p>Contains no furniture. New furniture will be downloaded if the file doesn't exist.</p>
-						<p> - <a href="https://classichabbo.com/classichabbo_exe_lite.zip">Click here</a> to download (25 MB)</p>
+						<p style="margin-top:10px; margin-right:10px">At this time there is just one version of the portable client which can be used across Windows, Linux, & macOS.</p>
+						<p><b>Portable Desktop Client:</b></p>
+						<p>The download includes the Habbo Shockwave client files, furni & sound files, and the necessary Director Xtras required to function.</p>
+						<p> - <a href="https://inf-o-matic.com/downloads/habbo-client-v0.1.0.zip"">Click here</a> to download (~170 MB)</p>
+						<p><b>Basilisk Portable Browser:</b></p>
+						<p>For those who possibly don't want to use the desktop client but also don't want to install Shockwave.</p>
+						<p> - <a href="https://inf-o-matic.com/downloads/Basilisk-Portable.zip">Click here</a> to download (~220 MB)</p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Re-enable the Shockwave help pages for accessing the hotel with pages dedicated to getting the browser plugin or desktop client setup. Revamp the text found on each page as well